### PR TITLE
Use utc for start time

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -100,7 +100,7 @@ export default {
       shipOrder: [],
       log: [],
       shortUrl: null,
-      startOfGame: moment('2020-05-22 20:00'),
+      startOfGame: moment.utc('2020-05-22 18:00'),
       currentTime: moment()
     }
   },


### PR DESCRIPTION
currently, start time uses moment('{date time}') which is for local times 